### PR TITLE
2025 add crypto

### DIFF
--- a/crypto/2025/crypto_ønskomania_6000/index.md
+++ b/crypto/2025/crypto_ønskomania_6000/index.md
@@ -56,6 +56,8 @@ To exploit this, we simply needed to:
 
 We wrote a python script [solve_replay.py](scripts/solve_replay.py) that implements the client encryption (using the provided keys) and performs the replay attack.
 
+We can now move on to [Ønskomania 7000](/nc3/crypto/2025/crypto_ønskomania_7000)!
+
 ## Flag
 
 ```text

--- a/crypto/2025/crypto_ønskomania_6000/index.md
+++ b/crypto/2025/crypto_ønskomania_6000/index.md
@@ -1,0 +1,67 @@
++++
+title = 'Ønskomania 6000'
+categories = ['Crypto']
+date = 2025-12-02T10:03:59+01:00
+scrollToTop = true
++++
+
+
+## Challenge Name:
+
+Ønskomania 6000
+
+## Category:
+
+Crypto
+
+## Challenge Description:
+
+Julemanden har ansat det nyeste IT-firma i byen, BitNisse, i håb om at kunne uddelegere hele processen med at modtage ønsker fra alle verdens børn til én besked app. For at få alle børn til at bruge appen, har Julemanden lovet, at hvert ønske et barn sender til ham forøger deres chance for at få ekstra gaver!
+
+Da deadline for appen var 1. december, blev den kryptografiske protokol lidt halvfærdig, og nogle kryptografer er bange for, at tekniske hackerbørn kan få deres ønske registreret flere gange.
+
+Start server på TryHackMe og forbind med det udleverede client script eller direkte med
+nc <IP> 1337
+
+OBS: Opgaven åbner for en 2'er i serien, det er en af de skjulte under ???.
+
+https://tryhackme.com/jr/oenskomania6000
+
+Santa has hired a new IT company, BitNisse, to handle wishes via a new app. The protocol is "half-finished" and there's a concern that users can register their wishes multiple times. We are given the server source code, client source code, and keys. The goal is to exploit the protocol to register a wish multiple times.
+
+## Approach
+
+We analyzed [server.py](scripts/server.py) and [client.py](scripts/client.py).
+The server uses a static Diffie-Hellman shared secret (derived from keys loaded from files) to derive session keys using a salt provided by the client.
+The encryption is AES-GCM.
+
+The server logic has a specific check for "repeated messages":
+```python
+        if last_message is None:
+            print("🎄 Mange tak for dit første juleønske!")
+        elif ciphertext == last_message:
+            flag = Path("flag.txt")
+            if flag.exists():
+                print(flag.read_text().strip())
+            # ...
+            break
+```
+This logic explicitly releases the flag if the *exact same ciphertext* is received twice in a row (`ciphertext == last_message`).
+While the prompt says "INGEN GENTAGELSER!" (No Repetitions), the code actually rewards it.
+
+To exploit this, we simply needed to:
+1.  Construct a valid encrypted wish message using the provided keys and the client logic.
+2.  Send the wish to the server.
+3.  Send the exact same wish (replay) immediately after.
+
+We wrote a python script [solve_replay.py](scripts/solve_replay.py) that implements the client encryption (using the provided keys) and performs the replay attack.
+
+## Flag
+
+```text
+NC3{Mag1c_c0py_p4st3}
+```
+
+## Reflections and Learnings
+
+This challenge demonstrates a classic Replay Attack vulnerability. The server failed to enforce uniqueness or freshness (e.g., by checking nonces against a history or ensuring the message content hasn't been processed before in a way that prevents replays). Instead, the server logic specifically checked for a replay and released the flag, likely simulating a "debug" backdoor or a logic error where the condition for "detecting an attack" was wired to "reward the attacker". In a real secure system, a replay should be rejected (or ignored idempotent-ly) without side effects.

--- a/crypto/2025/crypto_ønskomania_6000/scripts/client.py
+++ b/crypto/2025/crypto_ønskomania_6000/scripts/client.py
@@ -1,0 +1,128 @@
+import os
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import serialization
+from pwn import *
+
+from helpers import thrift_encode_int
+
+
+context.log_level = 'error'
+
+# Generate shared secret:
+santa_public_key = serialization.load_pem_public_key(
+    Path("keys/santa_public_key.pem").read_bytes()
+)
+
+hacker_private_key = serialization.load_pem_private_key(
+    Path("keys/hacker_private_key.pem").read_bytes(),
+    password=None
+)
+
+shared_secret = hacker_private_key.exchange(santa_public_key)
+assert isinstance(shared_secret, bytes), "Shared secret skal være bytes"
+assert len(shared_secret) == 32, f"Shared secret skal være 32 bytes, fik {len(shared_secret)}"
+
+# Sizes
+AES_KEY_LEN = 32   # 256-bit AES key
+GCM_NONCE_LEN = 12
+HKDF_SALT_LEN = 16
+
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+
+def aesgcm_encrypt_with_shared(
+    key: bytes,
+    plaintext: bytes,
+    aad: bytes | None = None
+) -> bytes: # Returns: salt(16) || nonce(12) || ciphertext||tag
+    aesgcm = AESGCM(key)
+    
+    counter_file = Path("nonce_local_to_julemanden.txt")
+    try:
+        counter = int(counter_file.read_text())
+    except (FileNotFoundError, ValueError):
+        counter = 1
+    counter_file.write_text(str(counter + 1))
+
+    encoded_counter = thrift_encode_int(counter)   
+    counter_bytes = encoded_counter.ljust(8, b"\x00")[:8]
+    random_tail = os.urandom(4)
+
+    nonce = counter_bytes + random_tail
+    assert len(nonce) == 12
+
+    ct_and_tag = aesgcm.encrypt(nonce, plaintext, aad)
+
+    return nonce + ct_and_tag
+
+
+def aesgcm_decrypt_with_shared(
+    key: bytes, 
+    blob: bytes,
+    aad: bytes | None = None
+) -> bytes:
+    if len(blob) < GCM_NONCE_LEN + 16:  # minimal sanity: nonce + tag
+        raise ValueError("ciphertext blob for kort")
+
+    aesgcm = AESGCM(key)
+    nonce = blob[:GCM_NONCE_LEN]
+    ct_and_tag = blob[GCM_NONCE_LEN:]
+    return aesgcm.decrypt(nonce, ct_and_tag, aad)                      
+
+
+def encrypt_wish_for_santa(wish: str):
+    SantaID = 1
+
+    plaintext = bytearray(wish.encode())
+    aad_struct = {
+        "to_": SantaID
+    }
+    aad = bytearray(json.dumps(aad_struct, separators=(',', ':')).encode())
+    aad_len_bytes = len(aad).to_bytes(2, "big")
+    salt = os.urandom(16)
+    key = derive_aes_key(shared_secret, salt)
+    encrypted = aesgcm_encrypt_with_shared(key, plaintext, aad)
+    final_message = aad_len_bytes + aad + salt + encrypted
+    
+    return final_message
+
+
+def main():
+    HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+
+    with remote(HOST, 1337) as io:
+        print(io.recvline().decode())
+
+        while True:
+            try:
+                wish = input("🎁 Juleønske: ").strip()
+            except KeyboardInterrupt:
+                print("👋 Farvel!")
+                break
+
+            if wish:
+                ct = encrypt_wish_for_santa(wish)
+                io.sendlineafter(b"> ", ct.hex().encode())
+                response = io.recvline().decode()
+                print(response)
+            else:
+                io.sendlineafter(b"> ", b"")
+                print(io.recvline().decode())
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomania_6000/scripts/server.py
+++ b/crypto/2025/crypto_ønskomania_6000/scripts/server.py
@@ -1,0 +1,121 @@
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+# ======== Load Santa's private key from file ========
+santa_private_key = serialization.load_pem_private_key(
+    Path("keys/santa_private_key.pem").read_bytes(),
+    password=None
+)
+
+# ======== Load Santa's public key from file ========
+santa_public_key = serialization.load_pem_public_key(
+    Path("keys/santa_public_key.pem").read_bytes()
+)
+
+# ======== Load Hackers's public key from file ========
+hacker_public_key = serialization.load_pem_public_key(
+    Path("keys/hacker_public_key.pem").read_bytes()
+)
+
+# ======== Perform ECDH to derive shared secret ========
+shared_secret = santa_private_key.exchange(hacker_public_key)
+
+# Sizes
+AES_KEY_LEN = 32   # 256-bit AES key
+GCM_NONCE_LEN = 12
+HKDF_SALT_LEN = 16
+
+
+def log(message: str):
+    with Path("server.log").open("a") as f:
+        f.write(f"{message}\n")
+    print(message, file=sys.stderr)
+
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+
+def santa_decrypt_wish(
+    key: bytes, 
+    blob: bytes, #blob (nonce||ct||tag)
+    aad: bytes | None = None
+) -> bytes:
+    if len(blob) < GCM_NONCE_LEN + 16:  # minimal sanity: nonce + tag
+        raise ValueError("ciphertext blob for lille")
+
+    aesgcm = AESGCM(key)
+    nonce = blob[:GCM_NONCE_LEN]
+    ct_and_tag = blob[GCM_NONCE_LEN:]
+    return aesgcm.decrypt(nonce, ct_and_tag, aad)   
+
+
+def main():
+    # Ensure stdout is unbuffered for immediate output
+    sys.stdout.reconfigure(line_buffering=True)
+    
+    log("🎅 Forbindelse modtaget")
+    
+    print("🎅 Velkommen til Julemandens ønskeservice!")
+    
+    last_message: bytes | None = None
+    
+    while True:
+        print("\n🎁 Send et juleønske i hex (INGEN GENTAGELSER!):")
+        try:
+            ciphertext = bytes.fromhex(input("> "))
+        except ValueError:
+            print("Det er vist ikke korrekt hex, prøv igen")
+            continue
+        except (EOFError, KeyboardInterrupt):
+            print("👋 Farvel, tak for dine ønsker!")
+            break
+        
+        log(f"📥 Modtaget {len(ciphertext)} bytes")
+        
+        if len(ciphertext) == 0:
+            print("👋 Farvel, tak for dine ønsker!")
+            break
+
+        aad_len = int.from_bytes(ciphertext[:2], "big")
+        aad = ciphertext[2 : 2 + aad_len]
+        salt = ciphertext[2 + aad_len : 2 + aad_len + 16]
+        encrypted = ciphertext[2 + aad_len + 16 :]
+
+        aeskey = derive_aes_key(shared_secret, salt)
+        
+        try:
+            plaintext = santa_decrypt_wish(aeskey, encrypted, aad)
+            log(plaintext)
+        except Exception as e:
+            print(f"🚨 Hov, det ønske kunne ikke dekrypteres: {e}")
+            continue
+
+        if last_message is None:
+            print("🎄 Mange tak for dit første juleønske!")
+        elif ciphertext == last_message:
+            flag = Path("flag.txt")
+            if flag.exists():
+                print(flag.read_text().strip())
+            else:
+                print("Flaget er blevet væk!")
+            break
+        else:
+            print("✨ Tak for endnu et nyt ønske")
+
+        last_message = ciphertext
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomania_6000/scripts/solve_replay.py
+++ b/crypto/2025/crypto_ønskomania_6000/scripts/solve_replay.py
@@ -1,0 +1,155 @@
+import os
+import json
+import sys
+import socket
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import serialization
+
+from thrift.protocol.TCompactProtocol import TCompactProtocol
+from thrift.transport.TTransport import TMemoryBuffer
+from thrift.Thrift import TType
+
+# ---- THRIFT HELPER (from helpers.py) ----
+def thrift_encode_int(n: int) -> bytes:
+    buf = TMemoryBuffer()
+    proto = TCompactProtocol(buf)
+
+    proto.writeStructBegin("N")
+    proto.writeFieldBegin("v", TType.I32, 1)
+    proto.writeI32(n)
+    proto.writeFieldEnd()
+    proto.writeFieldStop()
+    proto.writeStructEnd()
+
+    return buf.getvalue()
+
+# ---- CRYPTO SETUP ----
+
+KEYS_DIR = Path("keys")
+SANTA_PUB_KEY_PATH = KEYS_DIR / "santa_public_key.pem"
+HACKER_PRIV_KEY_PATH = KEYS_DIR / "hacker_private_key.pem"
+
+if not SANTA_PUB_KEY_PATH.exists():
+    print(f"Error: {SANTA_PUB_KEY_PATH} not found.")
+    sys.exit(1)
+if not HACKER_PRIV_KEY_PATH.exists():
+    print(f"Error: {HACKER_PRIV_KEY_PATH} not found.")
+    sys.exit(1)
+
+santa_public_key = serialization.load_pem_public_key(
+    SANTA_PUB_KEY_PATH.read_bytes()
+)
+
+hacker_private_key = serialization.load_pem_private_key(
+    HACKER_PRIV_KEY_PATH.read_bytes(),
+    password=None
+)
+
+shared_secret = hacker_private_key.exchange(santa_public_key)
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+def aesgcm_encrypt_with_shared(
+    key: bytes,
+    plaintext: bytes,
+    aad: bytes | None = None
+) -> bytes: # Returns: salt(16) || nonce(12) || ciphertext||tag
+    aesgcm = AESGCM(key)
+    
+    # Use a fixed counter for reproducibility in this exploit
+    counter = 1337
+    encoded_counter = thrift_encode_int(counter)   
+    counter_bytes = encoded_counter.ljust(8, b"\x00")[:8]
+    random_tail = os.urandom(4)
+
+    nonce = counter_bytes + random_tail
+    # nonce length must be 12
+    
+    ct_and_tag = aesgcm.encrypt(nonce, plaintext, aad)
+
+    return nonce + ct_and_tag
+
+def encrypt_wish_for_santa(wish: str):
+    SantaID = 1
+
+    plaintext = bytearray(wish.encode())
+    aad_struct = {
+        "to_": SantaID
+    }
+    aad = bytearray(json.dumps(aad_struct, separators=(',', ':')).encode())
+    aad_len_bytes = len(aad).to_bytes(2, "big")
+    salt = os.urandom(16)
+    key = derive_aes_key(shared_secret, salt)
+    encrypted = aesgcm_encrypt_with_shared(key, plaintext, aad)
+    final_message = aad_len_bytes + aad + salt + encrypted
+    
+    return final_message
+
+# ---- NETWORK ----
+
+def recv_until(s, match_str):
+    buffer = b""
+    while True:
+        try:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buffer += chunk
+            print(chunk.decode('utf-8', errors='ignore'), end='', flush=True)
+            if match_str.encode() in buffer:
+                return buffer.decode('utf-8', errors='ignore')
+        except socket.timeout:
+            break
+    return buffer.decode('utf-8', errors='ignore')
+
+def solve():
+    HOST = "10.82.128.188"
+    PORT = 1337
+    
+    print(f"[*] Connecting to {HOST}:{PORT}...")
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect((HOST, PORT))
+    
+    # Read banner
+    recv_until(s, "Juleønske i hex (INGEN GENTAGELSER!):")
+    
+    # 1. Send a wish
+    wish_str = "I want a flag!"
+    print(f"\n[*] Sending wish: {wish_str}")
+    encrypted_msg = encrypt_wish_for_santa(wish_str)
+    hex_msg = encrypted_msg.hex()
+    
+    s.sendall(hex_msg.encode() + b"\n")
+    
+    # Receive response
+    response = recv_until(s, "Juleønske i hex (INGEN GENTAGELSER!):")
+    
+    # 2. Send the SAME wish again
+    print(f"\n[*] Sending REPLAY wish...")
+    s.sendall(hex_msg.encode() + b"\n")
+    
+    # Receive response (hopefully containing flag)
+    while True:
+        try:
+            chunk = s.recv(4096)
+            if not chunk: break
+            print(chunk.decode('utf-8', errors='ignore'), end='', flush=True)
+        except socket.timeout:
+            break
+            
+    s.close()
+
+if __name__ == "__main__":
+    solve()

--- a/crypto/2025/crypto_ønskomania_7000/index.md
+++ b/crypto/2025/crypto_ønskomania_7000/index.md
@@ -72,6 +72,8 @@ def aesgcm_encrypt_with_shared(key, plaintext, aad):
     return nonce + aesgcm.encrypt(nonce, plaintext, aad)
 ```
 
+We can now move on to the final chapter [Ønskomaten_v24_12](/nc3/crypto/2025/crypto_ønskomaten_v24_12)!
+
 ## Flag
 
 ```text

--- a/crypto/2025/crypto_ønskomania_7000/index.md
+++ b/crypto/2025/crypto_ønskomania_7000/index.md
@@ -1,0 +1,83 @@
++++
+title = 'Ønskomania 7000'
+categories = ['Crypto']
+date = 2025-12-02T10:04:59+01:00
+scrollToTop = true
++++
+
+## Challenge Name:
+
+Ønskomania 7000
+
+## Category:
+
+Crypto
+
+## Challenge Description:
+
+Julemanden er ved at være træt af gentagelser! BitNisse har fået en opsang, og serveren er nu blevet smart nok til, at den kan stoppe gentagelser! Men måske ikke helt smart nok?
+
+Start server på TryHackMe og forbind med det udleverede client script eller direkte med
+nc <IP> 1337
+
+https://tryhackme.com/jr/oensk0m4n1a7000
+
+This is a follow-up to Ønskomania 6000. The server claims to stop repetitions.
+The server introduces a "snowflake" check.
+
+## Approach
+
+We analyzed [server.py](scripts/server.py) and found the following logic:
+
+```python
+    # Inside santa_decrypt_wish
+    counter = nonce[:8]
+    encoded_int = int.from_bytes(counter[1:], "little")
+    legit = (encoded_int >> 1) ^ -(encoded_int & 1) >= 0
+    return ..., not legit
+
+    # Inside main
+    elif data == last_message:
+        if snowflake:
+            # Print flag
+        else:
+            print("🎅 Hohoho, prøver du nu at snyde igen?")
+```
+
+The server releases the flag only if we successfully replay a message (`data == last_message`) AND `snowflake` is True.
+`snowflake` is True if `legit` is False.
+`legit` is calculated using a ZigZag-like decoding check: `(n >> 1) ^ -(n & 1) >= 0`.
+This expression evaluates to a non-negative number if `n` (the encoded integer) is even (decodes to positive).
+It evaluates to a negative number if `n` is odd (decodes to negative).
+
+So, to make `legit` False, we need `encoded_int` to be **odd**.
+`encoded_int` is derived from the nonce: `int.from_bytes(nonce[1:8], "little")`.
+To make this integer odd, we simply need the first byte of the slice (`nonce[1]`) to be odd.
+
+We modified our client solver to manually construct a valid AES-GCM nonce where `nonce[1] = 1`.
+We then encrypted a wish using this nonce, sent it, and immediately replayed it.
+The server accepted the replay as a "snowflake" (special/non-legit counter) and released the flag.
+
+### Solver Script
+
+The solver [script](scripts/solve_snowflake.py) sets up the crypto keys, manually constructs the nonce, and performs the replay attack.
+
+```python
+def aesgcm_encrypt_with_shared(key, plaintext, aad):
+    aesgcm = AESGCM(key)
+    # Manual nonce construction to force "snowflake"
+    nonce = bytearray(12)
+    nonce[1] = 1  # Force odd integer interpretation
+    nonce = bytes(nonce)
+    return nonce + aesgcm.encrypt(nonce, plaintext, aad)
+```
+
+## Flag
+
+```text
+NC3{G0tt4_l0v3_z1g-z4g_3nc0d1ng}
+```
+
+## Reflections and Learnings
+
+The challenge relied on a specific implementation detail of how the server validated the "counter" embedded in the nonce. By understanding the bitwise logic (`ZigZag` decoding property), we could manipulate the nonce (which is chosen by the client) to bypass the protection and trigger the "snowflake" condition required to get the flag during a replay.

--- a/crypto/2025/crypto_ønskomania_7000/scripts/client.py
+++ b/crypto/2025/crypto_ønskomania_7000/scripts/client.py
@@ -1,0 +1,128 @@
+import os
+import json
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import serialization
+from pwn import *
+
+from helpers import thrift_encode_int
+
+
+context.log_level = 'error'
+
+# Generate shared secret:
+santa_public_key = serialization.load_pem_public_key(
+    Path("keys/santa_public_key.pem").read_bytes()
+)
+
+hacker_private_key = serialization.load_pem_private_key(
+    Path("keys/hacker_private_key.pem").read_bytes(),
+    password=None
+)
+
+shared_secret = hacker_private_key.exchange(santa_public_key)
+assert isinstance(shared_secret, bytes), "Shared secret skal være bytes"
+assert len(shared_secret) == 32, f"Shared secret skal være 32 bytes, fik {len(shared_secret)}"
+
+# Sizes
+AES_KEY_LEN = 32   # 256-bit AES key
+GCM_NONCE_LEN = 12
+HKDF_SALT_LEN = 16
+
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+
+def aesgcm_encrypt_with_shared(
+    key: bytes,
+    plaintext: bytes,
+    aad: bytes | None = None
+) -> bytes: # Returns: salt(16) || nonce(12) || ciphertext||tag
+    aesgcm = AESGCM(key)
+    
+    counter_file = Path("nonce_local_to_julemanden.txt")
+    try:
+        counter = int(counter_file.read_text())
+    except (FileNotFoundError, ValueError):
+        counter = 1
+    counter_file.write_text(str(counter + 1))
+
+    encoded_counter = thrift_encode_int(counter)   
+    counter_bytes = encoded_counter.ljust(8, b"\x00")[:8]
+    random_tail = os.urandom(4)
+
+    nonce = counter_bytes + random_tail
+    assert len(nonce) == 12
+
+    ct_and_tag = aesgcm.encrypt(nonce, plaintext, aad)
+
+    return nonce + ct_and_tag
+
+
+def aesgcm_decrypt_with_shared(
+    key: bytes, 
+    blob: bytes,
+    aad: bytes | None = None
+) -> bytes:
+    if len(blob) < GCM_NONCE_LEN + 16:  # minimal sanity: nonce + tag
+        raise ValueError("ciphertext blob for kort")
+
+    aesgcm = AESGCM(key)
+    nonce = blob[:GCM_NONCE_LEN]
+    ct_and_tag = blob[GCM_NONCE_LEN:]
+    return aesgcm.decrypt(nonce, ct_and_tag, aad)                      
+
+
+def encrypt_wish_for_santa(wish: str):
+    SantaID = 1
+
+    plaintext = bytearray(wish.encode())
+    aad_struct = {
+        "to_": SantaID
+    }
+    aad = bytearray(json.dumps(aad_struct, separators=(',', ':')).encode())
+    aad_len_bytes = len(aad).to_bytes(2, "big")
+    salt = os.urandom(16)
+    key = derive_aes_key(shared_secret, salt)
+    encrypted = aesgcm_encrypt_with_shared(key, plaintext, aad)
+    final_message = aad_len_bytes + aad + salt + encrypted
+    
+    return final_message
+
+
+def main():
+    HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+
+    with remote(HOST, 1337) as io:
+        print(io.recvline().decode())
+
+        while True:
+            try:
+                wish = input("🎁 Juleønske: ").strip()
+            except KeyboardInterrupt:
+                print("👋 Farvel!")
+                break
+
+            if wish:
+                ct = encrypt_wish_for_santa(wish)
+                io.sendlineafter(b"> ", ct.hex().encode())
+                response = io.recvline().decode()
+                print(response)
+            else:
+                io.sendlineafter(b"> ", b"")
+                print(io.recvline().decode())
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomania_7000/scripts/server.py
+++ b/crypto/2025/crypto_ønskomania_7000/scripts/server.py
@@ -1,0 +1,130 @@
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+# ======== Load Santa's private key from file ========
+santa_private_key = serialization.load_pem_private_key(
+    Path("keys/santa_private_key.pem").read_bytes(),
+    password=None
+)
+
+# ======== Load Santa's public key from file ========
+santa_public_key = serialization.load_pem_public_key(
+    Path("keys/santa_public_key.pem").read_bytes()
+)
+
+# ======== Load Hackers's public key from file ========
+hacker_public_key = serialization.load_pem_public_key(
+    Path("keys/hacker_public_key.pem").read_bytes()
+)
+
+# ======== Perform ECDH to derive shared secret ========
+shared_secret = santa_private_key.exchange(hacker_public_key)
+
+# Sizes
+AES_KEY_LEN = 32   # 256-bit AES key
+GCM_NONCE_LEN = 12
+HKDF_SALT_LEN = 16
+
+
+def log(message: str):
+    with Path("server.log").open("a") as f:
+        f.write(f"{message}\n")
+    print(message, file=sys.stderr)
+
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+
+def santa_decrypt_wish(
+    key: bytes, 
+    blob: bytes, #blob (nonce||ct||tag)
+    aad: bytes | None = None
+) -> bytes:
+    if len(blob) < GCM_NONCE_LEN + 16:  # minimal sanity: nonce + tag
+        raise ValueError("ciphertext blob for lille")
+
+    aesgcm = AESGCM(key)
+    nonce = blob[:GCM_NONCE_LEN]
+    ct_and_tag = blob[GCM_NONCE_LEN:]
+
+    counter = nonce[:8]
+    encoded_int = int.from_bytes(counter[1:], "little")
+
+    legit = (encoded_int >> 1) ^ -(encoded_int & 1) >= 0
+
+    return aesgcm.decrypt(nonce, ct_and_tag, aad), not legit
+
+
+def main():
+    # Ensure stdout is unbuffered for immediate output
+    sys.stdout.reconfigure(line_buffering=True)
+
+    log("🎅 Forbindelse modtaget")
+
+    print("🎅 Velkommen til Julemandens ønskeservice!")
+
+    last_message: bytes | None = None
+
+    while True:
+        print("\n🎁 Send et juleønske i hex (INGEN GENTAGELSER!):")
+        try:
+            data = bytes.fromhex(input("> "))
+        except ValueError:
+            print("Det er vist ikke korrekt hex, prøv igen")
+            continue
+        except (EOFError, KeyboardInterrupt):
+            print("👋 Farvel, tak for dine ønsker!")
+            break
+
+        log(f"📥 Modtaget {len(data)} bytes")
+
+        if len(data) == 0:
+            print("👋 Farvel, tak for dine ønsker!")
+            break
+
+        aad_len = int.from_bytes(data[:2], "big")
+        aad = data[2 : 2 + aad_len]
+        salt = data[2 + aad_len : 2 + aad_len + 16]
+        encrypted = data[2 + aad_len + 16 :]
+
+        aeskey = derive_aes_key(shared_secret, salt)
+
+        try:
+            plaintext, snowflake = santa_decrypt_wish(aeskey, encrypted, aad)
+            log(plaintext)
+        except Exception as e:
+            print(f"🚨 Hov, det ønske kunne ikke dekrypteres: {e}")
+            continue
+
+        if last_message is None:
+            print("🎄 Mange tak for dit første juleønske!")
+        elif data == last_message:
+            if snowflake:
+                flag = Path("flag.txt")
+                if flag.exists():
+                    print(flag.read_text().strip())
+                else:
+                    print("Flaget er blevet væk!")
+                break
+            else:
+                print("🎅 Hohoho, prøver du nu at snyde igen?")
+        else:
+            print("✨ Tak for endnu et nyt ønske")
+
+        last_message = data
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomania_7000/scripts/solve_snowflake.py
+++ b/crypto/2025/crypto_ønskomania_7000/scripts/solve_snowflake.py
@@ -1,0 +1,147 @@
+import socket
+import os
+import json
+import sys
+from pathlib import Path
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import serialization
+
+# ---- CRYPTO SETUP ----
+
+KEYS_DIR = Path("keys")
+SANTA_PUB_KEY_PATH = KEYS_DIR / "santa_public_key.pem"
+HACKER_PRIV_KEY_PATH = KEYS_DIR / "hacker_private_key.pem"
+
+if not SANTA_PUB_KEY_PATH.exists():
+    print(f"Error: {SANTA_PUB_KEY_PATH} not found.")
+    # Try absolute path fallback if running from root
+    base = Path("loot/Crypto/crypto_ønskomania_7000")
+    SANTA_PUB_KEY_PATH = base / "keys/santa_public_key.pem"
+    HACKER_PRIV_KEY_PATH = base / "keys/hacker_private_key.pem"
+    
+    if not SANTA_PUB_KEY_PATH.exists():
+        print("Could not find keys.")
+        sys.exit(1)
+
+santa_public_key = serialization.load_pem_public_key(
+    SANTA_PUB_KEY_PATH.read_bytes()
+)
+
+hacker_private_key = serialization.load_pem_private_key(
+    HACKER_PRIV_KEY_PATH.read_bytes(),
+    password=None
+)
+
+shared_secret = hacker_private_key.exchange(santa_public_key)
+
+def derive_aes_key(shared_secret: bytes, salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+    )
+    return hkdf.derive(shared_secret)
+
+def aesgcm_encrypt_with_shared(
+    key: bytes,
+    plaintext: bytes,
+    aad: bytes | None = None
+) -> bytes: # Returns: salt(16) || nonce(12) || ciphertext||tag
+    aesgcm = AESGCM(key)
+    
+    # WE NEED NONCE SUCH THAT:
+    # counter = nonce[:8]
+    # int.from_bytes(counter[1:], "little") IS ODD
+    # So nonce[1] must be odd.
+    
+    # Let's construct a nonce manually.
+    # byte 0 can be anything. byte 1 must be odd (e.g. 1).
+    # rest can be anything.
+    
+    nonce = bytearray(12)
+    nonce[1] = 1 
+    # nonce is now 00 01 00 ... 00
+    
+    nonce = bytes(nonce)
+    
+    ct_and_tag = aesgcm.encrypt(nonce, plaintext, aad)
+
+    return nonce + ct_and_tag
+
+def encrypt_wish_for_santa(wish: str):
+    SantaID = 1
+
+    plaintext = bytearray(wish.encode())
+    aad_struct = {
+        "to_": SantaID
+    }
+    aad = bytearray(json.dumps(aad_struct, separators=(',', ':')).encode())
+    aad_len_bytes = len(aad).to_bytes(2, "big")
+    salt = os.urandom(16)
+    key = derive_aes_key(shared_secret, salt)
+    encrypted = aesgcm_encrypt_with_shared(key, plaintext, aad)
+    final_message = aad_len_bytes + aad + salt + encrypted
+    
+    return final_message
+
+# ---- NETWORK ----
+
+def recv_until(s, match_str):
+    buffer = b""
+    while True:
+        try:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buffer += chunk
+            print(chunk.decode('utf-8', errors='ignore'), end='', flush=True)
+            if match_str.encode() in buffer:
+                return buffer.decode('utf-8', errors='ignore')
+        except socket.timeout:
+            break
+    return buffer.decode('utf-8', errors='ignore')
+
+def solve():
+    HOST = "10.82.130.242"
+    PORT = 1337
+    
+    print(f"[*] Connecting to {HOST}:{PORT}...")
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect((HOST, PORT))
+    
+    # Read banner
+    recv_until(s, "Juleønske i hex (INGEN GENTAGELSER!):")
+    
+    # 1. Send a "snowflake" wish
+    wish_str = "Snowflake wish!"
+    print(f"[*] Sending snowflake wish: {wish_str}")
+    encrypted_msg = encrypt_wish_for_santa(wish_str)
+    hex_msg = encrypted_msg.hex()
+    
+    s.sendall(hex_msg.encode() + b"\n")
+    
+    # Receive response
+    recv_until(s, "Juleønske i hex (INGEN GENTAGELSER!):")
+    
+    # 2. Send the SAME wish again (replay)
+    print(f"[*] Sending REPLAY wish...")
+    s.sendall(hex_msg.encode() + b"\n")
+    
+    # Receive response (hopefully containing flag)
+    # The server logic: if data == last_message: if snowflake: print flag.
+    
+    while True:
+        try:
+            chunk = s.recv(4096)
+            if not chunk: break
+            print(chunk.decode('utf-8', errors='ignore'), end='', flush=True)
+        except socket.timeout:
+            break
+            
+    s.close()
+
+if __name__ == "__main__":
+    solve()

--- a/crypto/2025/crypto_ønskomaten_v12_24/index.md
+++ b/crypto/2025/crypto_ønskomaten_v12_24/index.md
@@ -76,7 +76,7 @@ Finally, we convert the integers $a$ and $b$ back to bytes and concatenate them 
 
 Final solving script can be seen [here](scripts/solve.py)
 
-We can now move on to [Ønskomania 6000](/nc3/crypto/crypto_ønskomania_6000)!
+We can now move on to [Ønskomania 6000](/nc3/crypto/2025/crypto_ønskomania_6000)!
 
 ## Flag
 

--- a/crypto/2025/crypto_ønskomaten_v12_24/index.md
+++ b/crypto/2025/crypto_ønskomaten_v12_24/index.md
@@ -1,0 +1,87 @@
++++
+title = 'Ønskomaten v12.24'
+categories = ['Crypto']
+date = 2025-12-02
+scrollToTop = true
++++
+
+## Challenge Name:
+
+Ønskomaten v12.24
+
+## Category:
+
+Crypto
+
+## Challenge Description:
+Hele Nisseland er blevet underlagt det nye NISS3-direktiv, der stiller nye krav til datasikkerheden. Som følge heraf skal alle juleønsker nu krypteres inden afsendelse til Julemandens postkontor.
+
+Nissitaliseringsstyrelsen har valgt Niscompany som vinder af udbuddet om at udvikle og implementere en løsning, og de blev på rekordtid klar med Ønskomaten v12.24 - men gik det mon lidt for hurtigt?
+
+Start server på TryHackMe og forbind med
+nc <IP> 1337
+
+OBS: Opgaven åbner for en 2'er i serien, det er en af de skjulte under ???.
+
+https://tryhackme.com/jr/onskomatv1224
+
+We are presented with a "Wish Automaton" (Ønskomaten) running on a TCP server. We are provided with the source code [ønskomaten_v12_24.py](scripts/ønskomaten_v12_24.py). The service encrypts user input (wishes) using RSA. It displays the public key parameters $N$ and $e=3$.
+
+The source code reveals how the flag is hidden:
+```python
+# Julemandens hemmelige ønskeforstærkere
+mid = len(flag) // 2
+a = int.from_bytes(flag[:mid])
+b = int.from_bytes(flag[mid:])
+
+# ... loop ...
+m = int.from_bytes(wish.encode("latin-1"))
+c = encrypt(a * m + b)
+```
+The encryption is performed as $c = (a \cdot m + b)^e \pmod N$.
+We can interact with the service to send arbitrary wishes $m$ and receive the corresponding ciphertext $c$.
+
+## Approach
+
+The public exponent $e=3$ is very small. This often hints at attacks involving small message sizes or lack of padding.
+
+We can model the encryption as:
+$c = (a \cdot m + b)^3 \pmod N$
+
+We can send two chosen messages, for example, the characters '1' and '2'.
+In ASCII/Latin-1:
+- '1' is 49.
+- '2' is 50.
+
+So we send $m_1 = 49$ and $m_2 = 50$ to get:
+1. $c_1 = (49a + b)^3 \pmod N$
+2. $c_2 = (50a + b)^3 \pmod N$
+
+Let $v_1 = 49a + b$ and $v_2 = 50a + b$.
+The values $v_1$ and $v_2$ might be small enough that $v_1^3 < N$ and $v_2^3 < N$. If so, the modular reduction never happens (or happens very few times), and we can simply take the integer cube root of $c_1$ and $c_2$ to recover $v_1$ and $v_2$.
+
+We verified this hypothesis by taking the integer cube root of the received ciphertexts. They were indeed perfect cubes.
+
+Having recovered $v_1$ and $v_2$, we have a system of two linear equations:
+1. $v_1 = 49a + b$
+2. $v_2 = 50a + b$
+
+Subtracting (1) from (2):
+$v_2 - v_1 = (50a + b) - (49a + b) = a$
+
+Once we have $a$, we can find $b$:
+$b = v_1 - 49a$
+
+Finally, we convert the integers $a$ and $b$ back to bytes and concatenate them to form the flag.
+
+Final solving script can be seen [here](scripts/solve.py)
+
+## Flag
+
+```text
+NC3{f4st_cub3r00t_d3crypt10n_1s_4_f34tur3_n07_4_bug}
+```
+
+## Reflections and Learnings
+
+The challenge highlights the dangers of using small public exponents ($e=3$) without proper padding (like OAEP). Even though the message was transformed ($a \cdot m + b$), the linearity of the transformation combined with the ability to choose $m$ and the small exponent allowed us to treat the RSA encryption as a simple polynomial equation over the integers rather than a modular one. This is a variant of the "Low Public Exponent Attack".

--- a/crypto/2025/crypto_ønskomaten_v12_24/index.md
+++ b/crypto/2025/crypto_ønskomaten_v12_24/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Ønskomaten v12.24'
 categories = ['Crypto']
-date = 2025-12-02
+date = 2025-12-02T10:02:59+01:00
 scrollToTop = true
 +++
 

--- a/crypto/2025/crypto_ønskomaten_v12_24/index.md
+++ b/crypto/2025/crypto_ønskomaten_v12_24/index.md
@@ -76,6 +76,8 @@ Finally, we convert the integers $a$ and $b$ back to bytes and concatenate them 
 
 Final solving script can be seen [here](scripts/solve.py)
 
+We can now move on to [Ønskomania 6000](/nc3/crypto/crypto_ønskomania_6000)!
+
 ## Flag
 
 ```text

--- a/crypto/2025/crypto_ønskomaten_v12_24/scripts/solve.py
+++ b/crypto/2025/crypto_ønskomaten_v12_24/scripts/solve.py
@@ -1,0 +1,62 @@
+import socket
+import re
+
+def iroot(n, k):
+    """Integer k-th root of n."""
+    if n == 0: return 0
+    u, s = n, n + 1
+    while u < s:
+        s = u
+        t = (k - 1) * s + n // pow(s, k - 1)
+        u = t // k
+    return s
+
+def recv_until(s, match_str):
+    buffer = b""
+    while True:
+        chunk = s.recv(4096)
+        if not chunk: break
+        buffer += chunk
+        if match_str.encode() in buffer:
+            return buffer.decode('utf-8', errors='ignore')
+    return buffer.decode('utf-8', errors='ignore')
+
+def solve():
+    host = "10.82.141.55"
+    port = 1337
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+
+    # Read banner for N
+    data = recv_until(s, "Juleønske:")
+    n_match = re.search(r"N = (\d+)", data)
+    N = int(n_match.group(1))
+
+    # Send '1'
+    s.send(b"1\n")
+    data = recv_until(s, "Juleønske:")
+    c1 = int(re.search(r"Krypteret: ([0-9a-f]+)", data).group(1), 16)
+
+    # Send '2'
+    s.send(b"2\n")
+    data = recv_until(s, "Juleønske:")
+    c2 = int(re.search(r"Krypteret: ([0-9a-f]+)", data).group(1), 16)
+    
+    s.close()
+
+    # Cube roots
+    v1 = iroot(c1, 3)
+    v2 = iroot(c2, 3)
+
+    # Solve linear system
+    a = v2 - v1
+    b = v1 - 49 * a
+    
+    # Decode
+    len_a = (a.bit_length() + 7) // 8
+    len_b = (b.bit_length() + 7) // 8
+    flag = a.to_bytes(len_a, 'big') + b.to_bytes(len_b, 'big')
+    print(flag.decode('latin-1'))
+
+if __name__ == "__main__":
+    solve()

--- a/crypto/2025/crypto_ønskomaten_v12_24/scripts/ønskomaten_v12_24.py
+++ b/crypto/2025/crypto_ønskomaten_v12_24/scripts/ønskomaten_v12_24.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from config import N, e, d, flag
+from string import printable
+
+CHARACTERS = printable + "æøåÆØÅ"
+
+def encrypt(m: int) -> int:
+    return pow(m, e, N)
+
+def decrypt(c: int) -> int:
+    return pow(c, d, N)
+
+def print_banner():
+    print("=== 🎄 NISSELANDS ØNSKOMAT v12.24 🎄 ===")
+    print()
+    print("Velkommen til Nisselands Ønskekrypteringsstation!")
+    print("Alle juleønsker skal krypteres før afsendelse til Julemandens postkontor,")
+    print("i henhold til det nye NISS3-direktiv.")
+    print()
+    print("🎅 Julemandens offentlige nøgle: 🎅")
+    print()
+    print(f"  e = {e}")
+    print(f"  N = {N}")
+    print()
+    print("Indtast dine ønsker ét af gangen, så krypteres de af Ønskomaten.")
+    print()
+    print("Tryk ENTER uden tekst for at afslutte.")
+    print()
+
+def main():
+    print_banner()
+
+    # Julemandens hemmelige ønskeforstærkere
+    mid = len(flag) // 2
+    a = int.from_bytes(flag[:mid])
+    b = int.from_bytes(flag[mid:])
+
+    while True:
+        wish = input("🎁 Juleønske: ").strip()
+        if not wish:
+            print("\n⛄ Ønskomaten lukker ned. Glædelig jul! 🎄")
+            break
+        
+        if set(wish) - set(CHARACTERS):
+            print("🚨 Ugyldigt ønske! Ønskomaten supporterer endnu ikke de tegn!\n")
+            continue
+
+        m = int.from_bytes(wish.encode("latin-1"))
+        c = encrypt(a * m + b)
+
+        print(f"✨ Krypteret: {hex(c)[2:]}\n")
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomaten_v24_12/index.md
+++ b/crypto/2025/crypto_ønskomaten_v24_12/index.md
@@ -1,0 +1,77 @@
++++ title = 'Ønskomaten v24.12'
+categories = ['Crypto']
+date = 2025-12-02T10:05:59+01:00
+scrollToTop = true
++++
+
+## Challenge Name:
+
+Ønskomaten v24.12
+
+## Category:
+
+Crypto
+
+## Challenge Description:
+
+Godt fundet - den kritiske sårbarhed i Ønskomaten v12.24 er nu lukket! Niscompany har udrullet en opdateret version: v24.12:
+
+PATCH NOTES
+
+🔐 Sikkerhed: Beskeder paddes nu til minimum 16 bytes for at forhindre det tidligere angreb.
+🌐 Kompatibilitet: Fuld understøttelse af Unicode, så alle verdens børn kan sende ønsker på eget sprog (메리 크리스마스) og vigtigere med emojis (🎄💥).
+⚡ Performance: Krypteringspipeline optimeret - hastighed øget ~300% efter massiv investering i Monster til krypteringsnisserne.
+Start server på TryHackMe og forbind med
+nc <IP> 1337
+
+https://tryhackme.com/jr/onskomatenv2412
+
+[This](scripts/ønskomaten_v24_12.py) is a patched version of the previous Ønskomaten challenge. The changes include:
+- Padding messages to 16 bytes.
+- Support for Unicode/Emojis.
+- "Optimized" encryption pipeline.
+
+The encryption logic is:
+```python
+m = int.from_bytes(pad(wish))
+c = encrypt(a * m + b)
+```
+where `pad(m)` ensures the message is at least 16 bytes. $N$ and $e=3$ are provided.
+
+## Approach
+
+Although the message $m$ is now larger (due to padding), the transformation is still linear: $M = a \cdot m + b$.
+The encryption is $c = (a \cdot m + b)^3 \pmod N$.
+
+We can rewrite this as a polynomial in terms of the unknown coefficients $a$ and $b$:
+$(am + b)^3 = a^3 m^3 + 3a^2b m^2 + 3ab^2 m + b^3 \pmod N$.
+
+We can control $m$ by sending different wishes. Let $X = a^3, Y = a^2b, Z = ab^2, W = b^3$.
+Then for each message $m_i$, we have a linear equation:
+$m_i^3 X + 3m_i^2 Y + 3m_i Z + W = c_i \pmod N$.
+
+Since there are 4 unknowns ($X, Y, Z, W$), we need 4 linearly independent equations. We can obtain these by sending 4 different wishes (e.g., "1", "2", "3", "4").
+
+After solving the linear system for $X$ (which is $a^3$) and $W$ (which is $b^3$), we can recover $a$ and $b$ by taking the integer cube root. This works because $a$ and $b$ are derived from the flag and are small enough such that $a^3 < N$ and $b^3 < N$ (or at least, the modular reduction doesn't destroy the ability to recover them via roots, especially if $N$ is large enough compared to the flag size).
+
+### Solver Script
+
+The [solver](scripts/solve_final.py) implements the following steps:
+1.  Connect to the server and parse $N$.
+2.  Send 4 distinct wishes ("1", "2", "3", "4") and record the ciphertexts.
+3.  Calculate the corresponding padded integer values $m_1, m_2, m_3, m_4$.
+4.  Construct a $4 \times 4$ matrix where each row $i$ is $[m_i^3, 3m_i^2, 3m_i, 1]$ and the target vector is $[c_1, c_2, c_3, c_4]$.
+5.  Solve the linear system modulo $N$ using Gaussian elimination.
+6.  Extract $a^3$ and $b^3$ from the solution vector.
+7.  Compute the integer cube roots to find $a$ and $b$.
+8.  Convert $a$ and $b$ to bytes and concatenate them to reveal the flag.
+
+## Flag
+
+```text
+NC3{fr4nkl1n_4nd_r31t3rs_m3ss4g3s_4r3_s0_r3l4t4bl3_m4n!}
+```
+
+## Reflections and Learnings
+
+This challenge demonstrates that adding linear padding or simple linear transformations does not protect RSA with small exponents against linearization attacks. If the relationship between the plaintext and the ciphertext can be expressed as a system of linear equations with a small number of unknowns, the system can be solved efficiently. The "patch" failed to address the underlying vulnerability of using a small exponent with a linear relation.

--- a/crypto/2025/crypto_ønskomaten_v24_12/scripts/solve_final.py
+++ b/crypto/2025/crypto_ønskomaten_v24_12/scripts/solve_final.py
@@ -1,0 +1,186 @@
+import socket
+import re
+import sys
+import time
+
+# --- Utils ---
+def iroot(n, k):
+    """Integer k-th root of n."""
+    if n == 0: return 0
+    u, s = n, n + 1
+    while u < s:
+        s = u
+        t = (k - 1) * s + n // pow(s, k - 1)
+        u = t // k
+    return s
+
+def extended_gcd(a, b):
+    if a == 0:
+        return b, 0, 1
+    else:
+        g, y, x = extended_gcd(b % a, a)
+        return g, x - (b // a) * y, y
+
+def modinv(a, m):
+    g, x, y = extended_gcd(a, m)
+    if g != 1:
+        raise Exception('modular inverse does not exist')
+    else:
+        return x % m
+
+# --- Solver ---
+
+def pad(m: str) -> int:
+    # Re-implement server padding logic
+    # m.encode(errors="surrogateescape").lstrip(b"\x00").ljust(16, b"=")
+    b_str = m.encode('utf-8') 
+    padded = b_str.lstrip(b"\x00").ljust(16, b"=")
+    return int.from_bytes(padded, 'big')
+
+def solve_linear_system(coeffs, constants, N):
+    """
+    Solve M * x = C mod N
+    coeffs: 4x4 matrix (list of lists)
+    constants: list of 4 values
+    Returns list of 4 values
+    """
+    n = 4
+    M = [row[:] for row in coeffs]
+    C = constants[:]
+    
+    for i in range(n):
+        pivot = M[i][i]
+        if pivot == 0:
+            for j in range(i+1, n):
+                if M[j][i] != 0:
+                    M[i], M[j] = M[j], M[i]
+                    C[i], C[j] = C[j], C[i]
+                    pivot = M[i][i]
+                    break
+            if pivot == 0:
+                raise Exception("Singular matrix")
+        
+        inv = modinv(pivot, N)
+        for j in range(i, n):
+            M[i][j] = (M[i][j] * inv) % N
+        C[i] = (C[i] * inv) % N
+        
+        for k in range(n):
+            if k != i:
+                factor = M[k][i]
+                for j in range(i, n):
+                    M[k][j] = (M[k][j] - factor * M[i][j]) % N
+                C[k] = (C[k] - factor * C[i]) % N
+                
+    return C
+
+def recv_until(s, match_str):
+    buffer = b""
+    while True:
+        try:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buffer += chunk
+            print(chunk.decode('utf-8', errors='ignore'), end='', flush=True)
+            if match_str.encode() in buffer:
+                return buffer.decode('utf-8', errors='ignore')
+        except socket.timeout:
+            break
+    return buffer.decode('utf-8', errors='ignore')
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <IP>")
+        sys.exit(1)
+        
+    host = sys.argv[1]
+    port = 1337
+    
+    print(f"[*] Connecting to {host}:{port}")
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect((host, port))
+    
+    # Read N
+    print("[*] Reading banner...")
+    data = recv_until(s, "Juleønske:")
+    
+    n_match = re.search(r"N = (\d+)", data)
+    if not n_match:
+        print("[-] Could not find N in banner")
+        return
+        
+    N = int(n_match.group(1))
+    print(f"[+] N = {N}")
+    
+    inputs = ["1", "2", "3", "4"]
+    ms = [pad(x) for x in inputs]
+    cs = []
+    
+    for i, inp in enumerate(inputs):
+        print(f"[*] Sending wish: {inp}")
+        s.sendall(inp.encode() + b"\n")
+        
+        data = recv_until(s, "Juleønske:")
+        
+        c_match = re.search(r"Krypteret: ([0-9a-f]+)", data)
+        if c_match:
+            c = int(c_match.group(1), 16)
+            cs.append(c)
+        else:
+            print("[-] Failed to get ciphertext")
+            return
+                
+    s.close()
+    
+    # Build Matrix
+    # Coeffs of [a^3, a^2b, ab^2, b^3]
+    # Row: [m^3, 3m^2, 3m, 1]
+    
+    matrix = []
+    for m in ms:
+        row = [
+            pow(m, 3, N),
+            (3 * pow(m, 2, N)) % N,
+            (3 * m) % N,
+            1
+        ]
+        matrix.append(row)
+        
+    print("[*] Solving linear system...")
+    try:
+        sol = solve_linear_system(matrix, cs, N)
+        a3, a2b, ab2, b3 = sol
+        
+        print(f"[+] a^3 = {a3}")
+        print(f"[+] b^3 = {b3}")
+        
+        # Try cube roots
+        a = iroot(a3, 3)
+        b = iroot(b3, 3)
+        
+        if pow(a, 3) == a3:
+            print("[+] Found exact cube root for a!")
+        else:
+            print("[-] a^3 is not a perfect cube (modulo reduction occurred?)")
+            
+        if pow(b, 3) == b3:
+            print("[+] Found exact cube root for b!")
+        else:
+            print("[-] b^3 is not a perfect cube (modulo reduction occurred?)")
+            
+        # Decode
+        try:
+            flag_a = a.to_bytes((a.bit_length() + 7) // 8, 'big')
+            flag_b = b.to_bytes((b.bit_length() + 7) // 8, 'big')
+            flag = flag_a + flag_b
+            print(f"\n🎉 FLAG: {flag.decode('utf-8', errors='replace')}")
+        except Exception as e:
+            print(f"Error decoding: {e}")
+            
+    except Exception as e:
+        print(f"[-] Solver failed: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/crypto/2025/crypto_ønskomaten_v24_12/scripts/ønskomaten_v24_12.py
+++ b/crypto/2025/crypto_ønskomaten_v24_12/scripts/ønskomaten_v24_12.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from config import N, e, d, flag
+
+def encrypt(m: int) -> int:
+    return pow(m, e, N)
+
+def decrypt(c: int) -> int:
+    return pow(c, d, N)
+
+def pad(m: str) -> bytes:
+    return m.encode(errors="surrogateescape").lstrip(b"\x00").ljust(16, b"=")
+
+def print_banner():
+    print("=== 🎄 NISSELANDS ØNSKOMAT v24.12 🎄 ===")
+    print()
+    print("Velkommen til Nisselands opdaterede Ønskekrypteringsstation!")
+    print("Alle juleønsker skal krypteres før afsendelse til Julemandens postkontor,")
+    print("i henhold til det nye NISS3-direktiv.")
+    print()
+    print("🎅 Julemandens offentlige nøgle: 🎅")
+    print()
+    print(f"  e = {e}")
+    print(f"  N = {N}")
+    print()
+    print("Indtast dine ønsker ét af gangen, så krypteres de af Ønskomaten.")
+    print()
+    print("Tryk ENTER uden tekst for at afslutte.")
+    print()
+
+def main():
+    print_banner()
+
+    # Julemandens hemmelige ønskeforstærkere
+    mid = len(flag) // 2
+    a = int.from_bytes(flag[:mid])
+    b = int.from_bytes(flag[mid:])
+
+    while True:
+        wish = input("🎁 Juleønske: ").strip()
+        if not wish:
+            print("\n⛄ Ønskomaten lukker ned. Glædelig jul! 🎄")
+            break
+
+        m = int.from_bytes(pad(wish))
+        c = encrypt(a * m + b)
+
+        print(f"✨ Krypteret: {hex(c)[2:]}\n")
+
+if __name__ == "__main__":
+    main()

--- a/kom-godt-i-gang/2025/warmup_den_bærende_opskrift/index.md
+++ b/kom-godt-i-gang/2025/warmup_den_bærende_opskrift/index.md
@@ -1,5 +1,5 @@
 +++
-date = "2025-12-01"
+date = "2025-12-01T10:04:59+01:00"
 title = "Den Bærende Opskrift"
 categories = ['Kom godt i gang']
 slug = "warmup_den_bærende_opskrift"

--- a/kom-godt-i-gang/2025/warmup_rensdyrrygter/index.md
+++ b/kom-godt-i-gang/2025/warmup_rensdyrrygter/index.md
@@ -1,5 +1,5 @@
 +++
-date = "2025-12-01"
+date = "2025-12-01T10:05:59+01:00"
 title = "Rensdyrrygter"
 categories = ['Kom godt i gang']
 slug = "warmup_rensdyrrygter"

--- a/kom-godt-i-gang/2025/warmup_snissnap/index.md
+++ b/kom-godt-i-gang/2025/warmup_snissnap/index.md
@@ -1,5 +1,5 @@
 +++
-date = "2025-12-01"
+date = "2025-12-01T10:03:59+01:00"
 title = "Snissnap"
 categories = ['Kom godt i gang']
 tags = ["CTF", "NC3", "Crypto", "Encoding"]


### PR DESCRIPTION
This pull request introduces two new crypto challenge writeups, `Ønskomania 6000` and its sequel `Ønskomania 7000`, along with supporting client/server scripts and solver scripts. The challenges focus on exploiting weaknesses in a custom cryptographic protocol used by Santa's wish app, specifically targeting replay attacks and nonce validation logic. The most important changes are grouped below by challenge.

**Ønskomania 6000: Replay Attack Challenge**

* Added a detailed writeup in `crypto/2025/crypto_ønskomania_6000/index.md` describing the challenge, the server’s logic, and how a replay attack yields the flag due to a logic error in handling repeated ciphertexts.
* Implemented `client.py` and `server.py` scripts demonstrating the protocol: ECDH key exchange, AES-GCM encryption, and the server’s vulnerable wish-handling logic. [[1]](diffhunk://#diff-621f637c35f623841128adb2d07a5be3a969cf2c38c234dc36f02db00a491ac4R1-R128) [[2]](diffhunk://#diff-0389573519a198e4bf08199c81bcbc669826665b517406adb0bf1eac64bfa15cR1-R121)
* Added `solve_replay.py`, a solver script that exploits the replay vulnerability by sending the same encrypted wish twice to obtain the flag.

**Ønskomania 7000: Nonce Manipulation Challenge**

* Added a new writeup in `crypto/2025/crypto_ønskomania_7000/index.md` explaining the improved server logic, which attempts to block replays using a ZigZag-decoded nonce check, and how to bypass it by crafting a specific nonce.
* Provided an updated `client.py` for the new challenge, supporting the same encryption logic but ready for further nonce manipulation as required by the solver.

These additions document and automate the exploitation of cryptographic protocol flaws, demonstrating how replay attacks and nonce encoding can be leveraged to bypass server-side protections.