### PR TITLE
Add permissions for GitHub Actions to manage labels and assignees

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: PR Auto Assign & Label + Notify aCTF-Writeup
 
+# Grant the GITHUB_TOKEN permissions needed for adding labels/assignees
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Introduce permissions for the GITHUB_TOKEN to enable adding labels and assignees in GitHub Actions.