### PR TITLE
Add PR preview workflow using Hugo for automatic deployment and commenting

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,86 @@
+name: PR Preview (Hugo)
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # Skip previews for forked PRs to avoid permission and token issues
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout site shell (aCTF-Writeup)
+        uses: actions/checkout@v4
+        with:
+          repository: onero/aCTF-Writeup
+          path: actf
+
+      - name: Checkout PR content into submodule path
+        uses: actions/checkout@v4
+        with:
+          repository: onero/CTF-NC3
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: actf/CTF-NC3
+
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.123.0'
+          extended: true
+
+      - name: Build site
+        working-directory: actf
+        run: hugo --minify
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: actf/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@v4
+    outputs:
+      page_url: ${{ steps.deploy-pages.outputs.page_url }}
+
+  comment:
+    needs: deploy
+    runs-on: ubuntu-latest
+    if: needs.deploy.result == 'success'
+    steps:
+      - name: Comment with preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ needs.deploy.outputs.page_url }}';
+            if (!url) {
+              core.warning('No preview URL found, skipping comment.');
+              return;
+            }
+            const body = `Hugo preview deployed: ${url}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
Introduce a GitHub Actions workflow that automatically builds and deploys a Hugo site for pull requests, along with commenting the preview URL on the PR. This enhances the review process by providing immediate access to the changes.